### PR TITLE
Added prefix path on include build interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,13 @@ add_library(
   ${SOURCE_FILES}
 )
 
+foreach(prefix IN LISTS CMAKE_PREFIX_PATH)
+    target_include_directories(
+        ekg PUBLIC
+        $<BUILD_INTERFACE:${prefix}/include>
+    )
+endforeach()
+
 target_include_directories(
   ekg PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>


### PR DESCRIPTION
This is a fix to add the prefix path as a build interface, solving the issue #51 